### PR TITLE
Fix var-to-String conversion errors for Windows

### DIFF
--- a/source/ui/ModelExplorer.h
+++ b/source/ui/ModelExplorer.h
@@ -204,10 +204,10 @@ public:
                        " Model");
     _info.setText(
         "Version " +
-        String(_ApiModelsData[_modelsList.getSelectedRow()]["Version"]) +
-        " - " + String(_ApiModelsData[_modelsList.getSelectedRow()]["Date"]) +
+        _ApiModelsData[_modelsList.getSelectedRow()]["Version"].toString() +
+        " - " + _ApiModelsData[_modelsList.getSelectedRow()]["Date"].toString() +
         "\nAuthor: " +
-        String(_ApiModelsData[_modelsList.getSelectedRow()]["Author"]));
+        _ApiModelsData[_modelsList.getSelectedRow()]["Author"].toString());
     _descriptionLabel.setText("Model Description:",
                               NotificationType::dontSendNotification);
     _description.setText(


### PR DESCRIPTION
Building on Windows [currently fails](https://github.com/acids-ircam/rave_vst/runs/7973053593?check_suite_focus=true) with errors such as:
```
D:\a\rave_vst\rave_vst\source\ui/ModelExplorer.h(207,1): error C2440: '<function-style-cast>': cannot convert from 'const juce::var' to 'juce::String' [D:\a\rave_vst\rave_vst\build\rave-vst.vcxproj]
D:\a\rave_vst\rave_vst\source\ui/ModelExplorer.h(207,1): message : No constructor could take the source type, or constructor overload resolution was ambiguous [D:\a\rave_vst\rave_vst\build\rave-vst.vcxproj]
```

This PR fixes those errors by using the `juce::var::toString()` method instead of passing the `juce::var` directly to the `juce::String` constructor in `ModelExplorer::selectedRowsChanged()`.

Successfully built + run locally on Windows, macOS, and Ubuntu.