### PR TITLE
Fix model parsing errors and support mono + v2 models

### DIFF
--- a/source/PluginProcessorProcessing.cpp
+++ b/source/PluginProcessorProcessing.cpp
@@ -32,17 +32,23 @@ void RaveAP::modelPerform() {
 #if DEBUG_PERFORM
       std::cout << "Current input size : " << frame.sizes() << std::endl;
 #endif DEBUG_PERFORM
-      std::vector<torch::Tensor> latent_probs = _rave->encode_amortized(frame);
-      latent_traj_mean = latent_probs[0];
-      at::Tensor latent_traj_std = latent_probs[1];
 
-#if DEBUG_PERFORM
-      std::cout << "mean shape" << latent_traj_mean.sizes() << std::endl;
-      std::cout << "std shape" << latent_traj_std.sizes() << std::endl;
-#endif
+      if (_rave->hasMethod("encode_amortized")) {
+        std::vector<torch::Tensor> latent_probs = _rave->encode_amortized(frame);
+        latent_traj_mean = latent_probs[0];
+        at::Tensor latent_traj_std = latent_probs[1];
 
-      latent_traj = latent_traj_mean +
-                    latent_traj_std * torch::randn_like(latent_traj_mean);
+  #if DEBUG_PERFORM
+        std::cout << "mean shape" << latent_traj_mean.sizes() << std::endl;
+        std::cout << "std shape" << latent_traj_std.sizes() << std::endl;
+  #endif
+
+        latent_traj = latent_traj_mean +
+                      latent_traj_std * torch::randn_like(latent_traj_mean);
+      } else {
+        latent_traj = _rave->encode(frame);
+        latent_traj_mean = latent_traj;
+      }
     }
 
 #if DEBUG_PERFORM

--- a/source/Rave.h
+++ b/source/Rave.h
@@ -165,8 +165,8 @@ public:
 
   at::Tensor getLatentBuffer() { return latent_buffer; }
 
-  bool hasMethod(const std::string& methodName) const {
-    return this->model.find_method(methodName).has_value();
+  bool hasMethod(const std::string& method_name) const {
+    return this->model.find_method(method_name).has_value();
   }
 
 private:

--- a/source/Rave.h
+++ b/source/Rave.h
@@ -155,6 +155,10 @@ public:
 
   at::Tensor getLatentBuffer() { return latent_buffer; }
 
+  bool hasMethod(const std::string& methodName) const {
+    return this->model.find_method(methodName).has_value();
+  }
+
 private:
   torch::jit::Module model;
   int sr;

--- a/source/Rave.h
+++ b/source/Rave.h
@@ -37,15 +37,21 @@ public:
               << std::endl;
 
     bool found_model_as_attribute = false;
+    bool found_stereo_attribute = false;
     for (auto const& attr : named_attributes) {
       if (attr.name == "_rave") {
         found_model_as_attribute = true;
         std::cout << "Found _rave model as named attribute" << std::endl;
       }
       else if (attr.name == "stereo" || attr.name == "_rave.stereo") {
+        found_stereo_attribute = true;
         stereo = attr.value.toBool();
         std::cout << "Stereo?" << (stereo ? "true" : "false") << std::endl;
       }
+    }
+
+    if (!found_stereo_attribute) {
+      stereo = false;
     }
 
     if (found_model_as_attribute) {

--- a/source/Rave.h
+++ b/source/Rave.h
@@ -217,7 +217,7 @@ private:
   int sr;
   int latent_size;
   bool has_prior = false;
-  bool stereo;
+  bool stereo = false;
   juce::String model_path;
   at::Tensor encode_params;
   at::Tensor decode_params;

--- a/source/Rave.h
+++ b/source/Rave.h
@@ -29,11 +29,19 @@ public:
 
     this->model_path = juce::String(rave_model_file);
     auto named_buffers = this->model.named_buffers();
+    auto named_attributes = this->model.named_attributes();
     this->has_prior = false;
     this->prior_params = torch::zeros({0});
 
     std::cout << "[ ] RAVE - Model successfully loaded: " << rave_model_file
               << std::endl;
+
+    for (auto const& i : named_attributes) {
+      if (i.name == "_rave.stereo") {
+        stereo = i.value.toBool();
+        std::cout << "Stereo?" << (stereo ? "true" : "false") << std::endl;
+      }
+    }
 
     for (auto const &i : named_buffers) {
       if (i.name == "_rave.sampling_rate") {
@@ -153,6 +161,8 @@ public:
 
   bool hasPrior() { return has_prior; }
 
+  bool isStereo() const { return stereo; }
+
   at::Tensor getLatentBuffer() { return latent_buffer; }
 
   bool hasMethod(const std::string& methodName) const {
@@ -164,6 +174,7 @@ private:
   int sr;
   int latent_size;
   bool has_prior = false;
+  bool stereo;
   juce::String model_path;
   at::Tensor encode_params;
   at::Tensor decode_params;

--- a/source/Rave.h
+++ b/source/Rave.h
@@ -36,38 +36,75 @@ public:
     std::cout << "[ ] RAVE - Model successfully loaded: " << rave_model_file
               << std::endl;
 
-    for (auto const& i : named_attributes) {
-      if (i.name == "_rave.stereo") {
-        stereo = i.value.toBool();
+    bool found_model_as_attribute = false;
+    for (auto const& attr : named_attributes) {
+      if (attr.name == "_rave") {
+        found_model_as_attribute = true;
+        std::cout << "Found _rave model as named attribute" << std::endl;
+      }
+      else if (attr.name == "stereo" || attr.name == "_rave.stereo") {
+        stereo = attr.value.toBool();
         std::cout << "Stereo?" << (stereo ? "true" : "false") << std::endl;
       }
     }
 
-    for (auto const &i : named_buffers) {
-      if (i.name == "_rave.sampling_rate") {
-        this->sr = i.value.item<int>();
-        std::cout << "\tSampling rate: " << this->sr << std::endl;
-      }
-      if (i.name == "_rave.latent_size") {
-        this->latent_size = i.value.item<int>();
-        std::cout << "\tLatent size: " << this->latent_size << std::endl;
-      }
-      if (i.name == "encode_params") {
-        this->encode_params = i.value;
-        std::cout << "\tEncode parameters: " << this->encode_params
-                  << std::endl;
-      }
-      if (i.name == "decode_params") {
-        this->decode_params = i.value;
-        std::cout << "\tDecode parameters: " << this->decode_params
-                  << std::endl;
-      }
-      if (i.name == "prior_params") {
-        this->prior_params = i.value;
-        this->has_prior = true;
-        std::cout << "\tPrior parameters: " << this->prior_params << std::endl;
+    if (found_model_as_attribute) {
+      // Use named buffers within _rave
+      for (auto const& buf : named_buffers) {
+        if (buf.name == "_rave.sampling_rate") {
+          this->sr = buf.value.item<int>();
+          std::cout << "\tSampling rate: " << this->sr << std::endl;
+        }
+        else if (buf.name == "_rave.latent_size") {
+          this->latent_size = buf.value.item<int>();
+          std::cout << "\tLatent size: " << this->latent_size << std::endl;
+        }
+        else if (buf.name == "encode_params") {
+          this->encode_params = buf.value;
+          std::cout << "\tEncode parameters: " << this->encode_params
+                    << std::endl;
+        }
+        else if (buf.name == "decode_params") {
+          this->decode_params = buf.value;
+          std::cout << "\tDecode parameters: " << this->decode_params
+                    << std::endl;
+        }
+        else if (buf.name == "prior_params") {
+          this->prior_params = buf.value;
+          this->has_prior = true;
+          std::cout << "\tPrior parameters: " << this->prior_params << std::endl;
+        }
       }
     }
+    else {
+      // Use top-level named attributes
+      for (auto const& attr : named_attributes) {
+        if (attr.name == "sampling_rate") {
+          this->sr = attr.value.toInt();
+          std::cout << "\tSampling rate: " << this->sr << std::endl;
+        }
+        else if (attr.name == "full_latent_size") {
+          this->latent_size = attr.value.toInt();
+          std::cout << "\tLatent size: " << this->latent_size << std::endl;
+        }
+        else if (attr.name == "encode_params") {
+          this->encode_params = attr.value.toTensor();
+          std::cout << "\tEncode parameters: " << this->encode_params
+            << std::endl;
+        }
+        else if (attr.name == "decode_params") {
+          this->decode_params = attr.value.toTensor();
+          std::cout << "\tDecode parameters: " << this->decode_params
+            << std::endl;
+        }
+        else if (attr.name == "prior_params") {
+          this->prior_params = attr.value.toTensor();
+          this->has_prior = true;
+          std::cout << "\tPrior parameters: " << this->prior_params << std::endl;
+        }
+      }
+    }
+
     std::cout << "\tFull latent size: " << getFullLatentDimensions()
               << std::endl;
     std::cout << "\tRatio: " << getModelRatio() << std::endl;


### PR DESCRIPTION
Currently the plugin crashes when running certain models (see #27, #28, #35, and #39) -- this PR fixes those model parsing errors.

There are 3 main parts to the fixes (roughly divided by commit): 
1. 5a8b2454549ed17928a4e714395a929c8702cc89: Use `encode()` when `encode_amortized()` is unavailable in the model
2. c17a814783df769932999588b1cb5b84b9548b7d: Check whether model supports stereo -- if not, send mono instead of stereo input into `decode()`. This enables support for mono models.
3. 35450abc23a8df7e9c05ea82c4e9a7171b79da7e: Check top_level `named_attributes` if available (instead of `named_buffers` within `_rave`). This enables support for RAVE v2 models.

Tested successfully with all the models currently on the [RAVE models download page](https://acids-ircam.github.io/rave_models_download). However, the `darbouka_onnx` model doesn't sound quite correct when run -- not sure whether this is due to the model being v2 or ONNX (will continue investigating), but at the very least the plugin should no longer crash.